### PR TITLE
Groundwork to allow Nomt to accept variable-length keys

### DIFF
--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -11,6 +11,9 @@
 //! child index, then adding 1. This disambiguated representation uniquely encodes all the page IDs
 //! in a fixed-width bit pattern as, essentially, a base-64 integer.
 
+// TODO: remove the 256 bit key path length limit. The Path is already handled as an ArrayVec, so it should
+// be just a matter of removing everything related to the depth limit, for example, HIGHEST_ENCODED_42.
+
 use crate::{page::DEPTH, trie::KeyPath};
 use arrayvec::ArrayVec;
 use bitvec::prelude::*;
@@ -263,8 +266,10 @@ pub struct PageIdsIterator {
 impl PageIdsIterator {
     /// Create a PageIds Iterator over a KeyPath
     pub fn new(key_path: KeyPath) -> Self {
+        // TODO: update to support var key len, for now, it just expects 32-byte keys.
+        assert_eq!(key_path.len(), 32);
         Self {
-            key_path: Uint::from_be_bytes(key_path),
+            key_path: Uint::from_be_bytes::<32>(key_path.try_into().unwrap()),
             page_id: Some(ROOT_PAGE_ID),
         }
     }

--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -210,7 +210,8 @@ impl PageId {
 
     /// Get the minimum key-path which could land in this page.
     pub fn min_key_path(&self) -> KeyPath {
-        let mut path = KeyPath::default();
+        // TODO: once var len keys are fully accepted, the base key will be vec![0]
+        let mut path = vec![0; 32];
         for (i, child_index) in self.path.iter().enumerate() {
             let bit_start = i * 6;
             let bit_end = bit_start + 6;
@@ -227,7 +228,8 @@ impl PageId {
 
     /// Get the maximum key-path which could land in this page.
     pub fn max_key_path(&self) -> KeyPath {
-        let mut path = KeyPath::default();
+        // TODO: once var len keys are fully accepted, the base key will be vec![0]
+        let mut path = vec![0; 32];
         for (i, child_index) in self.path.iter().enumerate() {
             let bit_start = i * 6;
             let bit_end = bit_start + 6;
@@ -349,7 +351,7 @@ mod tests {
         page_id_2[31] = 0b10000011; // (0b000001 + 1 << 6) + 0b000010 + 1
         let page_id_2 = PageId::decode(page_id_2).unwrap();
 
-        let mut page_ids = PageIdsIterator::new(key_path);
+        let mut page_ids = PageIdsIterator::new(key_path.to_vec());
         assert_eq!(page_ids.next(), Some(ROOT_PAGE_ID));
         assert_eq!(page_ids.next(), Some(page_id_1));
         assert_eq!(page_ids.next(), Some(page_id_2));
@@ -367,7 +369,7 @@ mod tests {
         page_id_2[30] = 0b0000001; // (0b00000011 << 6) + 0b111111 + 1 = (0b00000011 + 1) << 6
         let page_id_2 = PageId::decode(page_id_2).unwrap();
 
-        let mut page_ids = PageIdsIterator::new(key_path);
+        let mut page_ids = PageIdsIterator::new(key_path.to_vec());
         assert_eq!(page_ids.next(), Some(ROOT_PAGE_ID));
         assert_eq!(page_ids.next(), Some(page_id_1));
         assert_eq!(page_ids.next(), Some(page_id_2));
@@ -395,8 +397,8 @@ mod tests {
 
     #[test]
     fn test_page_id_overflow() {
-        let first_page_last_layer = PageIdsIterator::new([0u8; 32]).last().unwrap();
-        let last_page_last_layer = PageIdsIterator::new([255; 32]).last().unwrap();
+        let first_page_last_layer = PageIdsIterator::new([0u8; 32].to_vec()).last().unwrap();
+        let last_page_last_layer = PageIdsIterator::new([255; 32].to_vec()).last().unwrap();
         assert_eq!(
             Err(ChildPageIdError::PageIdOverflow),
             child_page_id(&first_page_last_layer, 0),

--- a/core/src/proof/multi_proof.rs
+++ b/core/src/proof/multi_proof.rs
@@ -507,6 +507,7 @@ fn verify_range<H: NodeHasher>(
         &end_path.terminal.path()[start_depth..],
     );
 
+    // TODO: support var len keys
     let common_len = start_depth + common_bits;
     // TODO: if `common_len` == 256 the multi-proof is malformed. error
 
@@ -710,7 +711,7 @@ pub fn verify_update<H: NodeHasher>(
     let ops_len = ops.len();
 
     // chain with dummy item for handling the last batch.
-    for (i, (key, op)) in ops.into_iter().chain(Some(([0u8; 32], None))).enumerate() {
+    for (i, (key, op)) in ops.into_iter().chain(Some((vec![], None))).enumerate() {
         let is_last = i == ops_len;
 
         if is_last {
@@ -750,7 +751,7 @@ pub fn verify_update<H: NodeHasher>(
                     return Err(MultiVerifyUpdateError::OpsOutOfOrder);
                 }
             }
-            last_key = Some(key);
+            last_key = Some(key.clone());
 
             // find terminal index for the operation, erroring if out of scope.
             let mut next_terminal_index = last_terminal_index.unwrap_or(0);

--- a/core/src/proof/multi_proof.rs
+++ b/core/src/proof/multi_proof.rs
@@ -922,13 +922,14 @@ mod tests {
 
     #[test]
     pub fn test_multiproof_creation_single_path_proof() {
-        let mut key_path = [0; 32];
+        let mut key_path = [0; 32].to_vec();
         key_path[0] = 0b10000000;
         let sibling1 = [1; 32];
         let sibling2 = [2; 32];
         let path_proof = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path, 256,
+                key_path.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling2],
         };
@@ -946,10 +947,10 @@ mod tests {
 
     #[test]
     pub fn test_multiproof_creation_two_path_proofs() {
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b00000000;
 
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b00111000;
 
         let sibling1 = [1; 32];
@@ -963,13 +964,15 @@ mod tests {
 
         let path_proof_1 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_1, 256,
+                key_path_1.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling2, sibling_x, sibling3, sibling4],
         };
         let path_proof_2 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_2, 256,
+                key_path_2.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling2, sibling_x, sibling5, sibling6],
         };
@@ -999,10 +1002,10 @@ mod tests {
 
     #[test]
     pub fn test_multiproof_creation_two_path_proofs_256_depth() {
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[31] = 0b00000000;
 
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[31] = 0b00000001;
 
         let mut siblings_1: Vec<[u8; 32]> = (0..255).map(|i| [i; 32]).collect();
@@ -1012,13 +1015,15 @@ mod tests {
 
         let path_proof_1 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_1, 256,
+                key_path_1.clone(),
+                256,
             )),
             siblings: siblings_1.clone(),
         };
         let path_proof_2 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_2, 256,
+                key_path_2.clone(),
+                256,
             )),
             siblings: siblings_2,
         };
@@ -1046,22 +1051,17 @@ mod tests {
 
     #[test]
     pub fn test_multiproof_creation_multiple_path_proofs() {
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b00000000;
-
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b01000000;
-
-        let mut key_path_3 = [0; 32];
+        let mut key_path_3 = [0; 32].to_vec();
         key_path_3[0] = 0b01001100;
-
-        let mut key_path_4 = [0; 32];
+        let mut key_path_4 = [0; 32].to_vec();
         key_path_4[0] = 0b11101100;
-
-        let mut key_path_5 = [0; 32];
+        let mut key_path_5 = [0; 32].to_vec();
         key_path_5[0] = 0b11110100;
-
-        let mut key_path_6 = [0; 32];
+        let mut key_path_6 = [0; 32].to_vec();
         key_path_6[0] = 0b11111000;
 
         let sibling1 = [1; 32];
@@ -1086,28 +1086,32 @@ mod tests {
 
         let path_proof_1 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_1, 256,
+                key_path_1.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling2],
         };
 
         let path_proof_2 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_2, 256,
+                key_path_2.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling3, sibling4, sibling5, sibling6, sibling7],
         };
 
         let path_proof_3 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_3, 256,
+                key_path_3.clone(),
+                256,
             )),
             siblings: vec![sibling1, sibling3, sibling4, sibling5, sibling8, sibling9],
         };
 
         let path_proof_4 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_4, 256,
+                key_path_4.clone(),
+                256,
             )),
             siblings: vec![
                 sibling10, sibling11, sibling12, sibling13, sibling14, sibling15,
@@ -1116,7 +1120,8 @@ mod tests {
 
         let path_proof_5 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_5, 256,
+                key_path_5.clone(),
+                256,
             )),
             siblings: vec![
                 sibling10, sibling11, sibling12, sibling16, sibling17, sibling18,
@@ -1125,7 +1130,8 @@ mod tests {
 
         let path_proof_6 = PathProof {
             terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(
-                key_path_6, 256,
+                key_path_6.clone(),
+                256,
             )),
             siblings: vec![sibling10, sibling11, sibling12, sibling16, sibling19],
         };
@@ -1185,22 +1191,17 @@ mod tests {
 
     #[test]
     pub fn test_multiproof_creation_ext_siblings_order() {
-        let mut key_path_0 = [0; 32];
+        let mut key_path_0 = [0; 32].to_vec();
         key_path_0[0] = 0b00001000;
-
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b00010000;
-
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b10000000;
-
-        let mut key_path_3 = [0; 32];
+        let mut key_path_3 = [0; 32].to_vec();
         key_path_3[0] = 0b10000010;
-
-        let mut key_path_4 = [0; 32];
+        let mut key_path_4 = [0; 32].to_vec();
         key_path_4[0] = 0b10010001;
-
-        let mut key_path_5 = [0; 32];
+        let mut key_path_5 = [0; 32].to_vec();
         key_path_5[0] = 0b10010011;
 
         let sibling1 = [1; 32];
@@ -1327,13 +1328,13 @@ mod tests {
 
         let verified_multi_proof = verify::<Blake3Hasher>(&multi_proof, TERMINATOR).unwrap();
 
-        let mut key_path_0 = [0; 32];
+        let mut key_path_0 = [0; 32].to_vec();
         key_path_0[0] = 0b00001000;
 
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b00010000;
 
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b10000000;
 
         let ops = vec![
@@ -1362,13 +1363,13 @@ mod tests {
         //   / \
         //  v0  v2
 
-        let mut key_path_0 = [0; 32];
+        let mut key_path_0 = [0; 32].to_vec();
         key_path_0[0] = 0b00000000;
 
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b10000000;
 
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b01000000;
 
         let leaf_0 = LeafData {
@@ -1425,27 +1426,23 @@ mod tests {
         //   / \
         //  v0  v2
 
-        let mut key_path_0 = [0; 32];
+        let mut key_path_0 = [0; 32].to_vec();
         key_path_0[0] = 0b00000000;
-
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b10000000;
-
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b01000000;
 
         let leaf_0 = LeafData {
-            key_path: key_path_0,
+            key_path: key_path_0.clone(),
             value_hash: [0; 32],
         };
-
         let leaf_1 = LeafData {
-            key_path: key_path_1,
+            key_path: key_path_1.clone(),
             value_hash: [1; 32],
         };
-
         let leaf_2 = LeafData {
-            key_path: key_path_2,
+            key_path: key_path_2.clone(),
             value_hash: [2; 32],
         };
 
@@ -1476,17 +1473,17 @@ mod tests {
 
         let verified = verify::<Blake3Hasher>(&multi_proof, root).unwrap();
 
-        let mut key_path_3 = key_path_1;
+        let mut key_path_3 = key_path_1.clone();
         key_path_3[0] = 0b10100000;
 
-        let mut key_path_4 = key_path_0;
+        let mut key_path_4 = key_path_0.clone();
         key_path_4[0] = 0b00000100;
 
         let ops = vec![
-            (key_path_0, Some([2; 32])),
-            (key_path_4, Some([1; 32])),
+            (key_path_0.clone(), Some([2; 32])),
+            (key_path_4.clone(), Some([1; 32])),
             (key_path_1, None),
-            (key_path_3, Some([1; 32])),
+            (key_path_3.clone(), Some([1; 32])),
         ];
 
         let final_state = vec![
@@ -1517,9 +1514,10 @@ mod tests {
         //         l8a l8b l8c l8d
 
         let make_leaf = |key_path, value_byte| {
+            let value_hash = [value_byte; 32];
             let leaf_data = LeafData {
                 key_path,
-                value_hash: [value_byte; 32],
+                value_hash,
             };
 
             let hash = Blake3Hasher::hash_leaf(&leaf_data);
@@ -1528,22 +1526,22 @@ mod tests {
         let internal_hash =
             |left, right| Blake3Hasher::hash_internal(&InternalData { left, right });
 
-        let mut key_path_0 = [0; 32];
+        let mut key_path_0 = [0; 32].to_vec();
         key_path_0[0] = 0b00000000;
 
-        let mut key_path_1 = [0; 32];
+        let mut key_path_1 = [0; 32].to_vec();
         key_path_1[0] = 0b00000001;
 
-        let mut key_path_2 = [0; 32];
+        let mut key_path_2 = [0; 32].to_vec();
         key_path_2[0] = 0b00001000;
 
-        let mut key_path_3 = [0; 32];
+        let mut key_path_3 = [0; 32].to_vec();
         key_path_3[0] = 0b00001001;
 
-        let (leaf_a, l8a) = make_leaf(key_path_0, 1);
-        let (leaf_b, l8b) = make_leaf(key_path_1, 1);
-        let (leaf_c, l8c) = make_leaf(key_path_2, 1);
-        let (leaf_d, l8d) = make_leaf(key_path_3, 1);
+        let (leaf_a, l8a) = make_leaf(key_path_0.clone(), 1);
+        let (leaf_b, l8b) = make_leaf(key_path_1.clone(), 1);
+        let (leaf_c, l8c) = make_leaf(key_path_2.clone(), 1);
+        let (leaf_d, l8d) = make_leaf(key_path_3.clone(), 1);
 
         let i7a = internal_hash(l8a, l8b);
         let i7b = internal_hash(l8c, l8d);
@@ -1594,7 +1592,10 @@ mod tests {
 
         let verified = verify::<Blake3Hasher>(&multi_proof, root).unwrap();
 
-        let ops = vec![(key_path_0, Some([69; 32])), (key_path_3, Some([69; 32]))];
+        let ops = vec![
+            (key_path_0.clone(), Some([69; 32])),
+            (key_path_3.clone(), Some([69; 32])),
+        ];
 
         let (_, l8a) = make_leaf(key_path_0, 69);
         let (_, l8b) = make_leaf(key_path_1, 1);
@@ -1635,7 +1636,7 @@ mod tests {
         //        / \                    /  \
         //       v0  v1                 v4   T
 
-        let path = |byte| [byte; 32];
+        let path = |byte| [byte; 32].to_vec();
 
         let k0 = path(0b00000000);
         let k1 = path(0b00011000);
@@ -1644,10 +1645,11 @@ mod tests {
         let k4 = path(0b11000011);
         let k5 = path(0b11100010);
 
-        let make_leaf = |key_path| {
+        let make_leaf = |key_path: Vec<u8>| {
+            let value_hash = [key_path[0]; 32];
             let leaf_data = LeafData {
                 key_path,
-                value_hash: [key_path[0]; 32],
+                value_hash,
             };
 
             let hash = Blake3Hasher::hash_leaf(&leaf_data);
@@ -1723,7 +1725,7 @@ mod tests {
         //               /  \
         //              v1  v2
 
-        let path = |byte| [byte; 32];
+        let path = |byte| [byte; 32].to_vec();
 
         let k0 = path(0b00000000);
         let k1 = path(0b10000000);
@@ -1731,10 +1733,11 @@ mod tests {
         let k3 = path(0b10011100);
         let k4 = path(0b10011110);
 
-        let make_leaf = |key_path| {
+        let make_leaf = |key_path: Vec<u8>| {
+            let value_hash = [key_path[0]; 32];
             let leaf_data = LeafData {
                 key_path,
-                value_hash: [key_path[0]; 32],
+                value_hash,
             };
 
             let hash = Blake3Hasher::hash_leaf(&leaf_data);
@@ -1807,7 +1810,7 @@ mod tests {
 
         // Helper to create KeyPath from BitVec (simplified, assumes short paths)
         let keypath_from_bits = |bits: &BitSlice<u8, Msb0>| -> KeyPath {
-            let mut kp = KeyPath::default();
+            let mut kp = vec![0; 32];
 
             for (i, bit) in bits.iter().by_vals().enumerate() {
                 if i >= 256 {

--- a/core/src/proof/path_proof.rs
+++ b/core/src/proof/path_proof.rs
@@ -77,6 +77,7 @@ impl PathProof {
         key_path: &BitSlice<u8, Msb0>,
         root: Node,
     ) -> Result<VerifiedPathProof, PathProofVerificationError> {
+        // TODO: support var len keys
         if self.siblings.len() > core::cmp::min(key_path.len(), 256) {
             return Err(PathProofVerificationError::TooManySiblings);
         }

--- a/core/src/trie.rs
+++ b/core/src/trie.rs
@@ -15,6 +15,9 @@
 
 use crate::hasher::NodeHasher;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// A node in the binary trie. In this schema, it is always 256 bits and is the hash of either
 /// an [`LeafData`] or [`InternalData`], or zeroed if it's a [`TERMINATOR`].
 ///
@@ -22,8 +25,8 @@ use crate::hasher::NodeHasher;
 /// nodes. Typically, this is done by setting the MSB.
 pub type Node = [u8; 32];
 
-/// The path to a key. All paths have a 256 bit fixed length.
-pub type KeyPath = [u8; 32];
+/// The path to a key.
+pub type KeyPath = Vec<u8>;
 
 /// The hash of a value. In this schema, it is always 256 bits.
 pub type ValueHash = [u8; 32];
@@ -90,6 +93,17 @@ pub struct LeafData {
     /// The actual location of this node may be anywhere along this path, depending on the other
     /// data within the trie.
     pub key_path: KeyPath,
+    /// The hash of the value carried in this leaf.
+    pub value_hash: ValueHash,
+}
+
+/// The data of a leaf node containg a reference to the KepyPath.
+pub struct LeafDataRef<'a> {
+    /// The total path to this value within the trie.
+    ///
+    /// The actual location of this node may be anywhere along this path, depending on the other
+    /// data within the trie.
+    pub key_path: &'a KeyPath,
     /// The hash of the value carried in this leaf.
     pub value_hash: ValueHash,
 }

--- a/core/src/trie_pos.rs
+++ b/core/src/trie_pos.rs
@@ -6,6 +6,8 @@ use crate::{
 use alloc::fmt;
 use bitvec::prelude::*;
 
+// TODO: update `path` to become a Vec<u8> without depth limitations
+
 /// Encapsulates logic for moving around in paged storage for a binary trie.
 #[derive(Clone)]
 #[cfg_attr(
@@ -44,6 +46,11 @@ impl TriePosition {
     pub fn from_path_and_depth(path: KeyPath, depth: u16) -> Self {
         assert_ne!(depth, 0, "depth must be non-zero");
         assert!(depth <= 256);
+
+        // TODO: update to support var key len
+        assert_eq!(path.len(), 32);
+        let path = path.try_into().unwrap();
+
         let page_path = last_page_path(&path, depth);
         TriePosition {
             path,
@@ -56,9 +63,10 @@ impl TriePosition {
     pub fn from_bitslice(slice: &BitSlice<u8, Msb0>) -> Self {
         assert!(slice.len() <= 256);
 
+        // TODO: update to support var key len
         let mut path = [0; 32];
         path.view_bits_mut::<Msb0>()[..slice.len()].copy_from_bitslice(slice);
-        Self::from_path_and_depth(path, slice.len() as u16)
+        Self::from_path_and_depth(path.to_vec(), slice.len() as u16)
     }
 
     /// Parse a `TriePosition` from a bit string.

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -272,6 +272,13 @@ mod tests {
             hash
         }
 
+        fn hash_leaf_ref(data: &trie::LeafDataRef) -> [u8; 32] {
+            Self::hash_leaf(&LeafData {
+                key_path: data.key_path.clone(),
+                value_hash: data.value_hash,
+            })
+        }
+
         fn hash_internal(data: &trie::InternalData) -> [u8; 32] {
             let mut hasher = blake3::Hasher::new();
             hasher.update(&data.left);
@@ -297,7 +304,7 @@ mod tests {
     fn leaf(key: u8) -> (LeafData, [u8; 32]) {
         let key = [key; 32];
         let leaf = trie::LeafData {
-            key_path: key.clone(),
+            key_path: key.to_vec(),
             value_hash: key.clone(),
         };
 
@@ -372,7 +379,7 @@ mod tests {
         let mut visited = Visited::at(bitvec![u8, Msb0; 0, 0, 0, 1]);
 
         let ops = [leaf_a, leaf_b, leaf_c]
-            .iter()
+            .into_iter()
             .map(|l| (l.key_path, l.value_hash))
             .collect::<Vec<_>>();
 
@@ -410,7 +417,7 @@ mod tests {
         let mut visited = Visited::default();
 
         let ops = [leaf_a, leaf_b, leaf_c, leaf_d, leaf_e]
-            .iter()
+            .into_iter()
             .map(|l| (l.key_path, l.value_hash))
             .collect::<Vec<_>>();
 

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -19,12 +19,12 @@ fn main() -> Result<()> {
         nomt.begin_session(SessionParams::default().witness_mode(WitnessMode::read_write()));
 
     // Reading a key from the database
-    let key_path = sha2::Sha256::digest(b"key").into();
-    let value = session.read(key_path)?;
+    let key_path = sha2::Sha256::digest(b"key").to_vec();
+    let value = session.read(key_path.clone())?;
 
     // Even though this key is only being read, we ask NOMT to warm up the on-disk data because
     // we will prove the read.
-    session.warm_up(key_path);
+    session.warm_up(key_path.clone());
 
     let mut finished = session
         .finish(vec![(key_path, KeyReadWrite::Read(value))])

--- a/examples/witness_verification/src/main.rs
+++ b/examples/witness_verification/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
                 // Verify the correctness of the returned value when it is Some(_)
                 Some(value_hash) => {
                     let leaf = LeafData {
-                        key_path: read.key,
+                        key_path: read.key.clone(),
                         value_hash,
                     };
                     assert!(verified.confirm_value(&leaf).unwrap());
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
             .skip_while(|r| r.path_index != i)
             .take_while(|r| r.path_index == i)
         {
-            write_ops.push((write.key, write.value));
+            write_ops.push((write.key.clone(), write.value));
         }
 
         if !write_ops.is_empty() {

--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -408,7 +408,6 @@ pub fn compressed_separator_range_size(
 }
 
 // Extract the key at a given index from a BranchNode, taking into account prefix compression.
-// TODO: This may eventually become something like &Key
 pub fn get_key(node: &BranchNode, index: usize) -> Key {
     let prefix = if index < node.prefix_compressed() as usize {
         Some(node.raw_prefix())

--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -114,11 +114,11 @@ impl BranchNode {
     }
 
     // Set the prefix extracting `self.prefix_len` bits from the provided key
-    fn set_prefix(&mut self, key: &[u8; 32]) {
+    fn set_prefix(&mut self, key: &Vec<u8>) {
         let start = BRANCH_NODE_HEADER_SIZE + self.n() as usize * 2;
         let prefix_len = self.prefix_len() as usize;
         let end = start + ((prefix_len + 7) / 8).next_multiple_of(8);
-        bitwise_memcpy(&mut self.as_mut_slice()[start..end], 0, key, 0, prefix_len);
+        bitwise_memcpy(&mut self.as_mut_slice()[start..end], 0, &key, 0, prefix_len);
     }
 
     fn cells_mut(&mut self) -> &mut [[u8; 2]] {
@@ -408,6 +408,7 @@ pub fn compressed_separator_range_size(
 }
 
 // Extract the key at a given index from a BranchNode, taking into account prefix compression.
+// TODO: This may eventually become something like &Key
 pub fn get_key(node: &BranchNode, index: usize) -> Key {
     let prefix = if index < node.prefix_compressed() as usize {
         Some(node.raw_prefix())

--- a/nomt/src/beatree/index.rs
+++ b/nomt/src/beatree/index.rs
@@ -19,18 +19,18 @@ impl Index {
     ///
     /// This is either a branch whose separator is exactly equal to this key or the branch with the
     /// highest separator less than the key.
-    pub fn lookup(&self, key: Key) -> Option<(Key, Arc<BranchNode>)> {
+    pub fn lookup(&self, key: &Key) -> Option<(Key, Arc<BranchNode>)> {
         self.first_key_map
-            .get_prev(&key)
+            .get_prev(key)
             .map(|(sep, b)| (sep.clone(), b.clone()))
     }
 
     /// Get the first separator greater than the given key.
-    pub fn next_key(&self, key: Key) -> Option<Key> {
+    pub fn next_key(&self, key: &Key) -> Option<&Key> {
         self.first_key_map
             .range(RangeFromExclusive { start: key })
             .next()
-            .map(|(k, _)| *k)
+            .map(|(k, _)| k)
     }
 
     /// Remove the branch with the given separator key.
@@ -49,11 +49,11 @@ impl Index {
     }
 }
 
-struct RangeFromExclusive {
-    start: Key,
+struct RangeFromExclusive<'a> {
+    start: &'a Key,
 }
 
-impl RangeBounds<Key> for RangeFromExclusive {
+impl<'a> RangeBounds<Key> for RangeFromExclusive<'a> {
     fn start_bound(&self) -> Bound<&Key> {
         Bound::Excluded(&self.start)
     }

--- a/nomt/src/beatree/iterator.rs
+++ b/nomt/src/beatree/iterator.rs
@@ -614,7 +614,7 @@ mod tests {
         let n = values.len();
         let total_value_size = n * 8;
         let mut builder = LeafBuilder::new(&PAGE_POOL, n, total_value_size);
-        let separator = values[0].0;
+        let separator = values[0].0.clone();
         for (key, value) in values {
             builder.push_cell(key, &encode_value(value), false);
         }
@@ -642,7 +642,8 @@ mod tests {
         let branch = BranchNode::new_in(&PAGE_POOL);
         let mut builder = BranchNodeBuilder::new(branch, n, n, prefix_len);
         for (key, pn) in leaves {
-            builder.push(key, bit_ops::separator_len(&key), pn.0);
+            let separator_len = bit_ops::separator_len(&key);
+            builder.push(key, separator_len, pn.0);
         }
 
         Arc::new(builder.finish())
@@ -658,8 +659,9 @@ mod tests {
         index
     }
 
+    // TODO: update this to use var len keys
     fn key(x: u16) -> Key {
-        let mut k = Key::default();
+        let mut k = vec![0; 32];
         k[0..2].copy_from_slice(&x.to_be_bytes());
         k
     }
@@ -696,7 +698,10 @@ mod tests {
             primary_staging,
             Some(secondary_staging),
             index,
-            Key::default(),
+            // TODO: Key::default() is not being used because right now the first
+            // key in the indes is [0;32] while vec![] will be used when the Index will
+            // be updated to use var len keys
+            vec![0; 32],
             None,
         );
         let mut collected = Vec::new();
@@ -715,6 +720,8 @@ mod tests {
 
     #[test]
     fn needed_leaves_is_accurate() {
+        let key = |x: u8| -> Key { vec![x; 32] };
+
         // split across 2 branches
         let branch_1 = build_branch(vec![(key(0), 69.into()), (key(4), 70.into())]);
         let branch_2 = build_branch(vec![(key(6), 420.into()), (key(8), 421.into())]);
@@ -726,7 +733,13 @@ mod tests {
             iter.needed_leaves().map(|pn| pn.0).collect::<Vec<_>>()
         };
 
-        assert_eq!(get_needed(Key::default(), None), vec![69, 70, 420, 421]);
+        // TODO: Key::default() is not being used because right now the first
+        // key in the indes is [0;32] while vec![0] will be used when the Index will
+        // be updated to use var len keys
+        assert_eq!(
+            get_needed(/* Key::default()  */ vec![0; 32], None),
+            vec![69, 70, 420, 421]
+        );
         assert_eq!(get_needed(key(2), Some(key(7))), vec![69, 70, 420]);
         assert_eq!(get_needed(key(4), Some(key(8))), vec![70, 420]);
     }
@@ -743,7 +756,8 @@ mod tests {
         {
             let start = key(2);
             let mut leaves = vec![leaf_1.clone(), leaf_2.clone()].into_iter();
-            let mut iter = BeatreeIterator::new(OrdMap::new(), None, index.clone(), start, None);
+            let mut iter =
+                BeatreeIterator::new(OrdMap::new(), None, index.clone(), start.clone(), None);
             while let Some(output) = iter.next() {
                 match output {
                     IterOutput::Blocked => iter.provide_leaf(LeafNodeRef {
@@ -769,8 +783,11 @@ mod tests {
                 OrdMap::new(),
                 None,
                 index.clone(),
-                Key::default(),
-                Some(end),
+                // TODO: Key::default() is not being used because right now the first
+                // key in the indes is [0;32] while vec![0] will be used when the Index will
+                // be updated to use var len keys
+                vec![0; 32],
+                Some(end.clone()),
             );
             while let Some(output) = iter.next() {
                 match output {
@@ -792,8 +809,11 @@ mod tests {
                 OrdMap::new(),
                 None,
                 index.clone(),
-                Key::default(),
-                Some(end),
+                // TODO: Key::default() is not being used because right now the first
+                // key in the indes is [0;32] while vec![0] will be used when the Index will
+                // be updated to use var len keys
+                vec![0; 32],
+                Some(end.clone()),
             );
             while let Some(output) = iter.next() {
                 match output {
@@ -822,8 +842,11 @@ mod tests {
                 OrdMap::new(),
                 None,
                 index.clone(),
-                Key::default(),
-                Some(end),
+                // TODO: Key::default() is not being used because right now the first
+                // key in the indes is [0;32] while vec![0] will be used when the Index will
+                // be updated to use var len keys
+                vec![0; 32],
+                Some(end.clone()),
             );
             while let Some(output) = iter.next() {
                 match output {

--- a/nomt/src/beatree/leaf/node.rs
+++ b/nomt/src/beatree/leaf/node.rs
@@ -152,7 +152,7 @@ impl LeafBuilder {
         let cell_pointer = &mut self.leaf.cell_pointers_mut()[self.index];
 
         // TODO: update to support var key len
-        assert_eq!(key.len(), 256);
+        assert_eq!(key.len(), 32);
         encode_cell_pointer(
             &mut cell_pointer[..],
             key.try_into().unwrap(),

--- a/nomt/src/beatree/ops/bit_ops.rs
+++ b/nomt/src/beatree/ops/bit_ops.rs
@@ -7,6 +7,7 @@ use crate::beatree::{
 pub fn separate(a: &Key, b: &Key) -> Key {
     //if b > a at some point b must have a 1 where a has a 0 and they are equal up to that point.
     let bit_len = prefix_len(a, b) + 1;
+    // TODO: bit_len will be longer than 32 bytes
     let mut separator = [0u8; 32];
 
     let full_bytes = bit_len / 8;
@@ -18,11 +19,13 @@ pub fn separate(a: &Key, b: &Key) -> Key {
         separator[full_bytes] = b[full_bytes] & mask;
     }
 
-    separator
+    separator.to_vec()
 }
 
 pub fn prefix_len(key_a: &Key, key_b: &Key) -> usize {
     let mut bit_len = 0;
+    // TODO: this probably will need to be updated to something like
+    // min(key_a.min(), key_b.min())
     'byte_loop: for byte in 0..32 {
         for bit in 0..8 {
             let mask = 1 << (7 - bit);
@@ -35,6 +38,7 @@ pub fn prefix_len(key_a: &Key, key_b: &Key) -> usize {
     bit_len
 }
 
+// TODO: keys wil be longer than 256 bits
 pub fn separator_len(key: &Key) -> usize {
     if key == &[0u8; 32] {
         return 1;
@@ -56,6 +60,7 @@ pub fn separator_len(key: &Key) -> usize {
 // Reconstruct a key starting from a prefix and a misaligned separator.
 // Note: bit offsets starts from 0 going to 7, and the most significant bit is the one with index 0
 pub fn reconstruct_key(maybe_prefix: Option<RawPrefix>, separator: RawSeparators) -> Key {
+    // TODO: key will be longer than 32 bytes
     let mut key = [0u8; 32];
 
     let prefix_bit_len = maybe_prefix.as_ref().map(|p| p.1).unwrap_or(0);
@@ -93,7 +98,7 @@ pub fn reconstruct_key(maybe_prefix: Option<RawPrefix>, separator: RawSeparators
         key[prefix_byte_len - 1] |= prefix.0[prefix_byte_len - 1] & mask;
     }
 
-    key
+    key.to_vec()
 }
 
 fn first_chunk_mask(bit_start: usize) -> u64 {

--- a/nomt/src/beatree/ops/reconstruction.rs
+++ b/nomt/src/beatree/ops/reconstruction.rs
@@ -60,7 +60,8 @@ pub fn reconstruct(
             separator[prefix.len()..prefix.len() + first.len()].copy_from_bitslice(first);
         }
 
-        if let Some(_) = index.insert(separator, Arc::new(branch)) {
+        // TODO: separtor will be already a vec
+        if let Some(_) = index.insert(separator.to_vec(), Arc::new(branch)) {
             bail!(
                 "2 branch nodes with same separator, separator={:?}",
                 separator

--- a/nomt/src/beatree/ops/update/branch_ops.rs
+++ b/nomt/src/beatree/ops/update/branch_ops.rs
@@ -465,10 +465,10 @@ mod tests {
             .map(|i| key(i))
             .take_while(|key| {
                 let res = !rightsized;
-                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
+                rightsized = gauge.body_size_after(&key, separator_len(key)) >= target;
 
                 if res {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                 }
                 res
             })
@@ -507,10 +507,10 @@ mod tests {
             .map(|i| (i, get_key(&branch, i)))
             .take_while(|(_i, key)| {
                 let res = !rightsized;
-                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
+                rightsized = gauge.body_size_after(&key, separator_len(key)) >= target;
 
                 if res {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                 }
                 res
             })
@@ -609,10 +609,10 @@ mod tests {
             .take_while(|key| {
                 let res = !rightsized;
                 rightsized =
-                    gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
+                    gauge.body_size_after(&key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
 
                 if res {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                 }
                 res
             })
@@ -658,10 +658,10 @@ mod tests {
             .take_while(|key| {
                 let res = !rightsized;
                 rightsized =
-                    gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
+                    gauge.body_size_after(&key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
 
                 if res {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                 }
                 res
             })
@@ -703,10 +703,10 @@ mod tests {
         ops_tracker.ops = (0..)
             .map(|i| compressed_key(i))
             .take_while(|key| {
-                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
+                if gauge.body_size_after(&key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
                     false
                 } else {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                     true
                 }
             })
@@ -731,10 +731,10 @@ mod tests {
             .take_while(|(_i, key)| {
                 let res = !rightsized;
                 rightsized =
-                    gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
+                    gauge.body_size_after(&key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
 
                 if res {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                 }
                 res
             })
@@ -753,8 +753,8 @@ mod tests {
         // requirement has been found has been updated to insert, but also all subsequent operations.
         for i in n_insert_op..res_ops.len() {
             assert!(matches!(
-                res_ops[i],
-                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
+                &res_ops[i],
+                BranchOp::Insert(k, PageNumber(_)) if *k == uncompressed_key(i - n_insert_op)
             ));
         }
 
@@ -776,10 +776,10 @@ mod tests {
         ops_tracker.ops = (0..)
             .map(|i| compressed_key(i))
             .take_while(|key| {
-                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
+                if gauge.body_size_after(&key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
                     false
                 } else {
-                    gauge.ingest_key(*key, separator_len(key));
+                    gauge.ingest_key(&key, separator_len(key));
                     true
                 }
             })
@@ -844,8 +844,8 @@ mod tests {
         // requirement has been found has been updated to insert, but also all subsequent operations.
         for i in n_insert_op..res_ops.len() {
             assert!(matches!(
-                res_ops[i],
-                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
+                &res_ops[i],
+                BranchOp::Insert(k, PageNumber(_)) if *k == uncompressed_key(i - n_insert_op)
             ));
         }
 
@@ -895,7 +895,7 @@ mod tests {
         let mut sum_separator_lengths = 0;
         for (key, _) in keys.clone() {
             let len = separator_len(&key);
-            base_node_gauge.ingest_key(key, len);
+            base_node_gauge.ingest_key(&key, len);
             sum_separator_lengths += len;
         }
 
@@ -992,7 +992,7 @@ mod tests {
         let mut sum_separator_lengths = 0;
         for (key, _) in keys.clone() {
             let len = separator_len(&key);
-            base_node_gauge.ingest_key(key, len);
+            base_node_gauge.ingest_key(&key, len);
             sum_separator_lengths += len;
         }
 
@@ -1017,12 +1017,12 @@ mod tests {
 
         // insert remains insert
         ops_tracker.replace_with_insert(None, 0);
-        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
+        assert!(matches!(&ops_tracker.ops[0], BranchOp::Insert(k,..) if *k == key(0)));
         assert_eq!(ops_tracker.ops.len(), 4);
 
         // update becomes insert
         ops_tracker.replace_with_insert(Some(&base), 1);
-        assert!(matches!(ops_tracker.ops[1], BranchOp::Insert(k,..) if k == key(1)));
+        assert!(matches!(&ops_tracker.ops[1], BranchOp::Insert(k,..) if *k == key(1)));
         assert_eq!(ops_tracker.ops.len(), 4);
 
         // keep becomes multiple inserts
@@ -1034,7 +1034,7 @@ mod tests {
             assert!(matches!(op, BranchOp::Insert(k,..) if *k == key(i + 2)));
         }
         assert!(
-            matches!(ops_tracker.ops[ops_tracker.ops.len() - 1], BranchOp::Insert(k,..) if k == key(n_keys + 2))
+            matches!(&ops_tracker.ops[ops_tracker.ops.len() - 1], BranchOp::Insert(k,..) if *k == key(n_keys + 2))
         );
         assert_eq!(ops_tracker.ops.len(), 2 + n_keys);
     }
@@ -1060,8 +1060,8 @@ mod tests {
 
         ops_tracker.extract_insert_from_keep_chunk(&base, 0);
         assert_eq!(ops_tracker.ops.len(), 2);
-        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
-        assert!(matches!(ops_tracker.ops[1], BranchOp::KeepChunk(c) if c.len() == n_keys - 1));
+        assert!(matches!(&ops_tracker.ops[0], BranchOp::Insert(k,..) if *k == key(0)));
+        assert!(matches!(&ops_tracker.ops[1], BranchOp::KeepChunk(c) if c.len() == n_keys - 1));
 
         // 0-sized chunks are not allowed.
         let chunk = KeepChunk {
@@ -1072,6 +1072,6 @@ mod tests {
         ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
         ops_tracker.extract_insert_from_keep_chunk(&base, 0);
         assert_eq!(ops_tracker.ops.len(), 1);
-        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
+        assert!(matches!(&ops_tracker.ops[0], BranchOp::Insert(k,..) if *k == key(0)));
     }
 }

--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -244,7 +244,8 @@ pub fn enforce_first_leaf_separator(
     // Initially set `maybe_new_first` to be the second leaf in the previous state.
     // It is an option because there may have been only one leaf in the previous state.
     // `maybe_new_first` always refers to leaves that were present previously.
-    let mut separator = vec![];
+    // TODO: once var len keys are fully supported this will need to become vec![0]
+    let mut separator = vec![0; 32];
     let mut maybe_new_first: Option<(Key, PageNumber)>;
 
     // Iterate over `leaf_changeset` until a non deleted item with a separator
@@ -253,7 +254,6 @@ pub fn enforce_first_leaf_separator(
     let mut idx = 1;
     loop {
         // `separator` is being eliminated, so it must exist in the previous state
-        // TODO: to_vec needs to be updated
         maybe_new_first = indexed_leaf(bbn_index, &separator)
             .map(|(_, maybe_next_separator, _)| maybe_next_separator)
             .flatten()

--- a/nomt/src/beatree/ops/update/leaf_updater.rs
+++ b/nomt/src/beatree/ops/update/leaf_updater.rs
@@ -291,7 +291,8 @@ impl LeafUpdater {
             .as_ref()
             .or(self.base.as_ref().map(|b| &b.separator))
             .cloned()
-            .unwrap_or(vec![])
+            // TODO: this will become a vec![0] once var len keys are fully supported
+            .unwrap_or(vec![0; 32])
     }
 
     // Starting from the specified index `from` within `self.ops`, consume and possibly
@@ -566,7 +567,7 @@ mod tests {
     }
 
     fn key(x: u8) -> Key {
-        [x; 32]
+        vec![x; 32]
     }
 
     fn make_leaf(vs: Vec<(Key, Vec<u8>, bool)>) -> Arc<LeafNode> {
@@ -955,7 +956,7 @@ mod tests {
 
         updater.try_build_leaves(&mut new_leaves, midpoint).unwrap();
 
-        let leaf_1 = &new_leaves.inner.get(&[0; 32]).unwrap().0;
+        let leaf_1 = &new_leaves.inner.get(&vec![0; 32]).unwrap().0;
         assert_eq!(leaf_1.n(), 3);
         let leaf_body_size = body_size(leaf_1.n(), leaf_1.values_size(0, leaf_1.n()));
         assert!(leaf_body_size < midpoint);
@@ -1001,7 +1002,7 @@ mod tests {
         updater.try_build_leaves(&mut new_leaves, midpoint).unwrap();
 
         // A leaf is perfectly created.
-        let leaf_1 = &new_leaves.inner.get(&[0; 32]).unwrap().0;
+        let leaf_1 = &new_leaves.inner.get(&vec![0; 32]).unwrap().0;
         assert_eq!(leaf_1.n(), 3);
         let leaf_body_size = body_size(3, leaf_1.values_size(0, 3));
         assert!(leaf_body_size > midpoint);
@@ -1115,7 +1116,7 @@ mod tests {
 
         let base = BaseLeaf {
             node: leaf.clone(),
-            separator: [0; 32],
+            separator: vec![0; 32],
             low: 0,
         };
 

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -162,14 +162,14 @@ impl<Node> NodesTracker<Node> {
         let entry = self.inner.entry(key).or_insert(ChangedNodeEntry {
             deleted: None,
             inserted: None,
-            next_separator,
+            next_separator: next_separator.clone(),
         });
 
         // we can only delete a node once.
         assert!(entry.deleted.is_none());
 
         entry.deleted.replace(pn);
-        entry.next_separator = next_separator;
+        entry.next_separator = next_separator.clone();
     }
 
     /// Add or modify a ChangedNodeEntry specifying an inserted Node.
@@ -183,7 +183,7 @@ impl<Node> NodesTracker<Node> {
         let entry = self.inner.entry(key).or_insert(ChangedNodeEntry {
             deleted: None,
             inserted: None,
-            next_separator,
+            next_separator: next_separator.clone(),
         });
 
         entry.next_separator = next_separator;

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -900,7 +900,10 @@ fn compute_root_node<H: HashAlgorithm>(page_cache: &PageCache, store: &Store) ->
 
     // cases 1/2
     let read_tx = store.read_transaction();
-    let mut iterator = read_tx.iterator(beatree::Key::default(), None);
+    // TODO: Once var len keys are fully supported, the first item will become vec![0]
+    // The reason is that the leaf iterator has an early return if nothing is found in the
+    // index, and nothing is found because the first item is [0; 32], which is bigger than [0].
+    let mut iterator = read_tx.iterator(vec![0; 32], None);
 
     let io_handle = store.io_pool().make_handle();
 

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -378,7 +378,7 @@ impl<T: HashAlgorithm> Nomt<T> {
         // Convert the traceback into a series of write commands.
         let mut actuals = Vec::new();
         for (key, value) in traceback {
-            sess.warm_up(key);
+            sess.warm_up(key.clone());
             let value = KeyReadWrite::Write(value);
             actuals.push((key, value));
         }

--- a/nomt/src/merkle/mod.rs
+++ b/nomt/src/merkle/mod.rs
@@ -429,14 +429,14 @@ impl UpdateHandle {
                             });
 
                             witness.operations.reads.push(WitnessedRead {
-                                key: *k,
+                                key: k.clone(),
                                 value: value_hash,
                                 path_index: path_index + path_proof_offset,
                             });
                         }
                         if let Some(written) = v.written_value() {
                             witness.operations.writes.push(WitnessedWrite {
-                                key: *k,
+                                key: k.clone(),
                                 value: written,
                                 path_index: path_index + path_proof_offset,
                             });

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -1000,7 +1000,7 @@ mod tests {
             let mut path = [0u8; 32];
             let slice = bits![u8, Msb0; $($t)+];
             path.view_bits_mut::<Msb0>()[..slice.len()].copy_from_bitslice(&slice);
-            path
+            path.to_vec()
         }}
     }
 
@@ -1222,7 +1222,7 @@ mod tests {
             &page_set,
             TriePosition::new(),
             vec![
-                (leaf_a_key_path, val(1)),
+                (leaf_a_key_path.clone(), val(1)),
                 (leaf_b_key_path, val(2)),
                 (leaf_c_key_path, val(3)),
                 (leaf_d_key_path, val(4)),
@@ -1373,11 +1373,11 @@ mod tests {
                 &page_set,
                 TriePosition::new(),
                 vec![
-                    (path_1, val(1)),
-                    (path_2, val(2)),
-                    (path_3, val(3)),
-                    (path_4, val(4)),
-                    (path_5, val(5)),
+                    (path_1.clone(), val(1)),
+                    (path_2.clone(), val(2)),
+                    (path_3.clone(), val(3)),
+                    (path_4.clone(), val(4)),
+                    (path_5.clone(), val(5)),
                 ],
             );
 
@@ -1400,10 +1400,10 @@ mod tests {
         };
 
         let expected_siblings = vec![
-            (node_hash(path_1, val(1)), 1),
-            (node_hash(path_2, val(2)), 2),
-            (node_hash(path_3, val(3)), 3),
-            (node_hash(path_4, val(4)), 4),
+            (node_hash(path_1.clone(), val(1)), 1),
+            (node_hash(path_2.clone(), val(2)), 2),
+            (node_hash(path_3.clone(), val(3)), 3),
+            (node_hash(path_4.clone(), val(4)), 4),
         ];
 
         // replace those leaf nodes one at a time.
@@ -1411,35 +1411,35 @@ mod tests {
 
         walker.advance_and_replace(
             &page_set,
-            TriePosition::from_path_and_depth(path_1, 4),
+            TriePosition::from_path_and_depth(path_1.clone(), 4),
             vec![(path_1, val(11))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..0]);
 
         walker.advance_and_replace(
             &page_set,
-            TriePosition::from_path_and_depth(path_2, 4),
+            TriePosition::from_path_and_depth(path_2.clone(), 4),
             vec![(path_2, val(12))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..1]);
 
         walker.advance_and_replace(
             &page_set,
-            TriePosition::from_path_and_depth(path_3, 4),
+            TriePosition::from_path_and_depth(path_3.clone(), 4),
             vec![(path_3, val(13))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..2]);
 
         walker.advance_and_replace(
             &page_set,
-            TriePosition::from_path_and_depth(path_4, 4),
+            TriePosition::from_path_and_depth(path_4.clone(), 4),
             vec![(path_4, val(14))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..3]);
 
         walker.advance_and_replace(
             &page_set,
-            TriePosition::from_path_and_depth(path_5, 4),
+            TriePosition::from_path_and_depth(path_5.clone(), 4),
             vec![(path_5, val(15))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..4]);
@@ -1530,7 +1530,7 @@ mod tests {
         let leaf_b_pos = trie_pos![0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1];
         let leaf_c_pos = trie_pos![0, 0, 1, 0, 0, 0, 0];
 
-        let mut page_id_iter = PageIdsIterator::new(leaf_a_key_path);
+        let mut page_id_iter = PageIdsIterator::new(leaf_a_key_path.clone());
         let root_page = page_id_iter.next().unwrap();
         let page_id_1 = page_id_iter.next().unwrap();
         let page_id_2 = page_id_iter.next().unwrap();
@@ -1612,7 +1612,7 @@ mod tests {
         let leaf_d_key_path = key_path![0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1];
         let cd_pos = trie_pos![0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1];
 
-        let mut page_id_iter = PageIdsIterator::new(leaf_c_key_path);
+        let mut page_id_iter = PageIdsIterator::new(leaf_c_key_path.clone());
         page_id_iter.next(); // root
         let page_id_1 = page_id_iter.next().unwrap();
         let page_id_2 = page_id_iter.next().unwrap();

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -435,7 +435,8 @@ impl RequestState {
 
 fn range_bounds(raw_path: KeyPath, depth: usize) -> (KeyPath, Option<KeyPath>) {
     if depth == 0 {
-        return (KeyPath::default(), None);
+        // TODO: once var-len keys are fully supported the first item in separator will become vec![0]
+        return (vec![0; 32], None);
     }
     let start = raw_path;
     let mut end = start.clone();
@@ -909,23 +910,24 @@ mod tests {
     #[test]
     fn key_range() {
         fn make_path(path: BitVec<u8, Msb0>) -> KeyPath {
-            let mut k = KeyPath::default();
+            // TODO: update with `KeyPath::default()` once we var-len keys are fully accepted
+            let mut k = vec![0; 32];
             k.view_bits_mut::<Msb0>()[..path.len()].copy_from_bitslice(&path);
             k
         }
 
         let key_a = make_path(bitvec![u8, Msb0; 0, 0, 0, 0]);
-        assert_eq!(range_bounds(key_a, 0).1, None);
+        assert_eq!(range_bounds(key_a.clone(), 0).1, None);
         assert_eq!(
-            range_bounds(key_a, 1).1,
+            range_bounds(key_a.clone(), 1).1,
             Some(make_path(bitvec![u8, Msb0; 1]))
         );
         assert_eq!(
-            range_bounds(key_a, 2).1,
+            range_bounds(key_a.clone(), 2).1,
             Some(make_path(bitvec![u8, Msb0; 0, 1]))
         );
         assert_eq!(
-            range_bounds(key_a, 3).1,
+            range_bounds(key_a.clone(), 3).1,
             Some(make_path(bitvec![u8, Msb0; 0, 0, 1]))
         );
         assert_eq!(
@@ -934,10 +936,10 @@ mod tests {
         );
 
         let key_b = make_path(bitvec![u8, Msb0; 1, 1, 1, 1]);
-        assert_eq!(range_bounds(key_b, 0).1, None);
-        assert_eq!(range_bounds(key_b, 1).1, None);
-        assert_eq!(range_bounds(key_b, 2).1, None);
-        assert_eq!(range_bounds(key_b, 3).1, None);
+        assert_eq!(range_bounds(key_b.clone(), 0).1, None);
+        assert_eq!(range_bounds(key_b.clone(), 1).1, None);
+        assert_eq!(range_bounds(key_b.clone(), 2).1, None);
+        assert_eq!(range_bounds(key_b.clone(), 3).1, None);
         assert_eq!(range_bounds(key_b, 4).1, None);
 
         let key_c = make_path(bitvec![u8, Msb0; 0, 1, 0]);

--- a/nomt/src/merkle/worker.rs
+++ b/nomt/src/merkle/worker.rs
@@ -136,7 +136,7 @@ fn warm_up_phase<H: HashAlgorithm>(
 
     loop {
         if let Some(result) = seeker.take_completion() {
-            warm_ups.insert(result.key, result);
+            warm_ups.insert(result.key.clone(), result);
             continue;
         }
 
@@ -182,7 +182,7 @@ fn warm_up_phase<H: HashAlgorithm>(
 
     while !seeker.is_empty() {
         if let Some(result) = seeker.take_completion() {
-            warm_ups.insert(result.key, result);
+            warm_ups.insert(result.key.clone(), result);
             continue;
         }
         seeker.submit_all(&mut page_set);
@@ -294,12 +294,12 @@ impl<H: HashAlgorithm> RangeUpdater<H> {
 
         let range_start = shared
             .read_write
-            .binary_search_by_key(&key_range_start, |x| x.0)
+            .binary_search_by_key(&&key_range_start, |x| &x.0)
             .unwrap_or_else(|i| i);
 
         let range_end = shared
             .read_write
-            .binary_search_by_key(&key_range_end, |x| x.0)
+            .binary_search_by_key(&&key_range_end, |x| &x.0)
             .unwrap_or_else(|i| i);
 
         RangeUpdater {
@@ -510,7 +510,8 @@ impl<H: HashAlgorithm> RangeUpdater<H> {
                         break;
                     }
                 } else {
-                    seeker.push(self.shared.read_write[next_push].0);
+                    // TODO: can this clone be removed? It could probably be replaced with std::mem::take
+                    seeker.push(self.shared.read_write[next_push].0.clone());
                     seeker.submit_all(page_set);
                 }
             }

--- a/nomt/src/overlay.rs
+++ b/nomt/src/overlay.rs
@@ -642,18 +642,18 @@ mod tests {
             BucketInfo::FreshOrDependent(SharedMaybeBucketIndex::new(None)),
         );
 
-        let key1 = [1; 32];
+        let key1 = vec![1; 32];
         let value1a = ValueChange::Insert(vec![1, 2, 3]);
         let value1b = ValueChange::Insert(vec![4, 5, 6]);
 
         let page_map = vec![(ROOT_PAGE_ID, page1a)].into_iter().collect();
-        let value_map = vec![(key1, value1a)].into_iter().collect();
+        let value_map = vec![(key1.clone(), value1a)].into_iter().collect();
         let a = LiveOverlay::new(None)
             .unwrap()
             .finish([0; 32], [1; 32], page_map, value_map, None);
 
         let page_map = vec![(ROOT_PAGE_ID, page1b)].into_iter().collect();
-        let value_map = vec![(key1, value1b)].into_iter().collect();
+        let value_map = vec![(key1.clone(), value1b)].into_iter().collect();
         let b = LiveOverlay::new(Some(&a))
             .unwrap()
             .finish([1; 32], [2; 32], page_map, value_map, None);
@@ -690,9 +690,9 @@ mod tests {
             BucketInfo::FreshOrDependent(SharedMaybeBucketIndex::new(None)),
         );
 
-        let key_1 = [1; 32];
-        let key_2 = [2; 32];
-        let key_3 = [3; 32];
+        let key_1 = vec![1; 32];
+        let key_2 = vec![2; 32];
+        let key_3 = vec![3; 32];
 
         let value_1 = ValueChange::Insert(vec![1, 2, 3]);
         let value_2 = ValueChange::Insert(vec![4, 5, 6]);
@@ -704,9 +704,9 @@ mod tests {
             (page_id_3.clone(), page_3),
         ];
         let values = [
-            (key_1, value_1.clone()),
-            (key_2, value_2.clone()),
-            (key_3, value_3.clone()),
+            (key_1.clone(), value_1.clone()),
+            (key_2.clone(), value_2.clone()),
+            (key_3.clone(), value_3.clone()),
         ];
 
         // build a chain of 3 overlays, each with one unique key and value.
@@ -806,10 +806,10 @@ mod tests {
             BucketInfo::FreshOrDependent(SharedMaybeBucketIndex::new(None)),
         );
 
-        let key_1 = [1; 32];
+        let key_1 = vec![1; 32];
         let val_1 = ValueChange::Insert(vec![1, 2, 3]);
 
-        let key_2 = [2; 32];
+        let key_2 = vec![2; 32];
         let val_2 = ValueChange::Insert(vec![4, 5, 6]);
         let val_2b = ValueChange::Insert(vec![7, 8, 9]);
 
@@ -819,15 +819,18 @@ mod tests {
         let page_map = vec![(page_id_1.clone(), page_1), (page_id_2.clone(), page_2)]
             .into_iter()
             .collect();
-        let value_map = vec![(key_1, val_1.clone()), (key_2, val_2.clone())]
-            .into_iter()
-            .collect();
+        let value_map = vec![
+            (key_1.clone(), val_1.clone()),
+            (key_2.clone(), val_2.clone()),
+        ]
+        .into_iter()
+        .collect();
         let a = LiveOverlay::new(None)
             .unwrap()
             .finish([0; 32], [1; 32], page_map, value_map, None);
 
         let page_map = vec![(page_id_2.clone(), page_2b)].into_iter().collect();
-        let value_map = vec![(key_2, val_2b.clone())].into_iter().collect();
+        let value_map = vec![(key_2.clone(), val_2b.clone())].into_iter().collect();
         let b = LiveOverlay::new([&a])
             .unwrap()
             .finish([0; 32], [1; 32], page_map, value_map, None);

--- a/nomt/src/rollback/delta.rs
+++ b/nomt/src/rollback/delta.rs
@@ -120,9 +120,9 @@ mod tests {
     #[test]
     fn delta_roundtrip() {
         let mut delta = Delta::empty();
-        delta.priors.insert([1; 32], Some(b"value1".to_vec()));
-        delta.priors.insert([2; 32], None);
-        delta.priors.insert([3; 32], Some(b"value3".to_vec()));
+        delta.priors.insert(vec![1; 32], Some(b"value1".to_vec()));
+        delta.priors.insert(vec![2; 32], None);
+        delta.priors.insert(vec![3; 32], Some(b"value3".to_vec()));
 
         let mut buf = delta.encode();
         let mut cursor = Cursor::new(&mut buf);

--- a/nomt/src/rollback/delta.rs
+++ b/nomt/src/rollback/delta.rs
@@ -78,9 +78,11 @@ impl Delta {
         let to_erase_len = u32::from_le_bytes(buf);
         // Read the keys to erase.
         for _ in 0..to_erase_len {
+            // TODO: used keys are still [0; 32] but soon it will be updated
+            // the encoding format will change
             let mut key_path = [0; 32];
             reader.read_exact(&mut key_path)?;
-            let preemted = priors.insert(key_path, None).is_some();
+            let preemted = priors.insert(key_path.to_vec(), None).is_some();
             if preemted {
                 anyhow::bail!("duplicate key path (erase): {:?}", key_path);
             }
@@ -92,6 +94,8 @@ impl Delta {
         // Read the keys to reinstate along with their values.
         for _ in 0..to_reinsate_len {
             // Read the key path.
+            // TODO: used keys are still [0; 32] but soon it will be updated
+            // the encoding format will change
             let mut key_path = [0; 32];
             reader.read_exact(&mut key_path)?;
             // Read the value.
@@ -100,7 +104,7 @@ impl Delta {
             let value_len = u32::from_le_bytes(buf);
             value.resize(value_len as usize, 0);
             reader.read_exact(&mut value)?;
-            let preempted = priors.insert(key_path, Some(value)).is_some();
+            let preempted = priors.insert(key_path.to_vec(), Some(value)).is_some();
             if preempted {
                 anyhow::bail!("duplicate key path (reinstate): {:?}", key_path);
             }

--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -430,12 +430,14 @@ impl ReverseDeltaBuilder {
                     } else {
                         // The delta builder was not aware of this write. Initiate a fetch from the store
                         // and record the result as a prior.
-                        let _ = self.command_tx.send(DeltaBuilderCommand::Lookup(*path));
+                        let _ = self
+                            .command_tx
+                            .send(DeltaBuilderCommand::Lookup(path.clone()));
                     }
                 }
                 KeyReadWrite::ReadThenWrite(prior, _) => {
                     // The path was read and then written. We could just keep the prior value.
-                    final_priors.insert(*path, prior.clone());
+                    final_priors.insert(path.clone(), prior.clone());
                 }
             }
         }

--- a/nomt/tests/compute_root.rs
+++ b/nomt/tests/compute_root.rs
@@ -17,8 +17,8 @@ fn root_on_empty_db() {
 fn root_on_leaf() {
     {
         let mut t = Test::new("compute_root_leaf");
-        t.write([1; 32], Some(vec![1, 2, 3]));
-        t.commit();
+        t.write(vec![1; 32], Some(vec![1, 2, 3]));
+        let (root, _) = t.commit();
     }
 
     let t = Test::new_with_params("compute_root_leaf", 1, 1, None, false);
@@ -33,8 +33,8 @@ fn root_on_leaf() {
 fn root_on_internal() {
     {
         let mut t = Test::new("compute_root_internal");
-        t.write([0; 32], Some(vec![1, 2, 3]));
-        t.write([1; 32], Some(vec![1, 2, 3]));
+        t.write(vec![0; 32], Some(vec![1, 2, 3]));
+        t.write(vec![1; 32], Some(vec![1, 2, 3]));
         t.commit();
     }
 

--- a/nomt/tests/extend_range_protocol.rs
+++ b/nomt/tests/extend_range_protocol.rs
@@ -57,8 +57,8 @@ fn insert_delete_and_read(name: impl AsRef<Path>, to_delete: Vec<u8>) {
     }
 }
 
-fn key(id: u8) -> [u8; 32] {
-    let mut key = [0; 32];
+fn key(id: u8) -> Vec<u8> {
+    let mut key = vec![0; 32];
     key[0] = id;
     key
 }

--- a/nomt/tests/fill_and_empty.rs
+++ b/nomt/tests/fill_and_empty.rs
@@ -40,10 +40,10 @@ fn fill_and_empty(seed: [u8; 16], commit_concurrency: usize) {
     // inserting all the values
     let mut to_check = vec![];
     for i in 0..db_size {
-        let key = items[i];
+        let key = items[i].clone();
         let value = vec![i as u8; 400];
 
-        to_check.push((key, value.clone()));
+        to_check.push((key.clone(), value.clone()));
         t.write(key, Some(value));
 
         if (i + 1) % commit_size == 0 {
@@ -58,9 +58,9 @@ fn fill_and_empty(seed: [u8; 16], commit_concurrency: usize) {
     // deleting all the values in different order
     let mut to_check = vec![];
     for i in 0..db_size {
-        let key = items[to_delete[i]];
+        let key = items[to_delete[i]].clone();
 
-        to_check.push(key);
+        to_check.push(key.clone());
         t.write(key, None);
 
         if (i + 1) % commit_size == 0 {
@@ -75,8 +75,9 @@ fn fill_and_empty(seed: [u8; 16], commit_concurrency: usize) {
     assert!(t.commit().0.is_empty());
 }
 
-fn rand_key(rng: &mut impl Rng) -> [u8; 32] {
-    let mut key = [0; 32];
+// TODO: update with random var key size when they will be fully supported
+fn rand_key(rng: &mut impl Rng) -> Vec<u8> {
+    let mut key = vec![0; 32];
     rng.fill(&mut key[..]);
     key
 }

--- a/nomt/tests/last_layer_trie.rs
+++ b/nomt/tests/last_layer_trie.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::Test;
 
+// TODO: with var-len keys this test will be removed
 #[test]
 fn last_layer_trie() {
     let mut t = Test::new_with_params(
@@ -12,28 +13,28 @@ fn last_layer_trie() {
         true,              // cleanup_dir
     );
 
-    let key1 = [170; 32];
+    let key1 = vec![170; 32];
     let mut key2 = key1.clone();
     key2[31] = 171;
 
     // write two leaf nodes at the last layer of the trie
-    t.write(key1, Some(vec![1; 128]));
-    t.write(key2, Some(vec![2; 128]));
+    t.write(key1.clone(), Some(vec![1; 128]));
+    t.write(key2.clone(), Some(vec![2; 128]));
     t.commit();
-    assert_eq!(t.read(key1), Some(vec![1; 128]));
-    assert_eq!(t.read(key2), Some(vec![2; 128]));
+    assert_eq!(t.read(key1.clone()), Some(vec![1; 128]));
+    assert_eq!(t.read(key2.clone()), Some(vec![2; 128]));
 
     // modify two leaf nodes at the last layer of the trie
-    t.write(key1, Some(vec![3; 100]));
-    t.write(key2, Some(vec![4; 100]));
+    t.write(key1.clone(), Some(vec![3; 100]));
+    t.write(key2.clone(), Some(vec![4; 100]));
     t.commit();
-    assert_eq!(t.read(key1), Some(vec![3; 100]));
-    assert_eq!(t.read(key2), Some(vec![4; 100]));
+    assert_eq!(t.read(key1.clone()), Some(vec![3; 100]));
+    assert_eq!(t.read(key2.clone()), Some(vec![4; 100]));
 
     // delete two leaf nodes at the last layer of the trie
-    t.write(key1, None);
-    t.write(key2, None);
+    t.write(key1.clone(), None);
+    t.write(key2.clone(), None);
     t.commit();
-    assert_eq!(t.read(key1), None);
-    assert_eq!(t.read(key2), None);
+    assert_eq!(t.read(key1.clone()), None);
+    assert_eq!(t.read(key2.clone()), None);
 }

--- a/nomt/tests/prev_root_check.rs
+++ b/nomt/tests/prev_root_check.rs
@@ -24,12 +24,18 @@ fn test_prev_root_commits() {
     let nomt = setup_nomt("prev_root_commits");
     let session1 = nomt.begin_session(SessionParams::default());
     let finished1 = session1
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
 
     let session2 = nomt.begin_session(SessionParams::default());
     let finished2 = session2
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
 
     finished1.commit(&nomt).unwrap();
@@ -42,13 +48,19 @@ fn test_prev_root_overlay_invalidated() {
     let nomt = setup_nomt("prev_root_overlay_invalidated");
     let session1 = nomt.begin_session(SessionParams::default());
     let finished1 = session1
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
     let overlay1 = finished1.into_overlay();
 
     let session2 = nomt.begin_session(SessionParams::default());
     let finished2 = session2
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
 
     finished2.commit(&nomt).unwrap();
@@ -61,13 +73,19 @@ fn test_prev_root_overlay_invalidates_session() {
     let nomt = setup_nomt("prev_root_overlays");
     let session1 = nomt.begin_session(SessionParams::default());
     let finished1 = session1
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
     let overlay1 = finished1.into_overlay();
 
     let session2 = nomt.begin_session(SessionParams::default());
     let finished2 = session2
-        .finish(vec![([1; 32], KeyReadWrite::Write(Some(vec![1, 2, 3])))])
+        .finish(vec![(
+            vec![1; 32],
+            KeyReadWrite::Write(Some(vec![1, 2, 3])),
+        )])
         .unwrap();
 
     overlay1.commit(&nomt).unwrap();

--- a/nomt/tests/witness_check.rs
+++ b/nomt/tests/witness_check.rs
@@ -60,7 +60,7 @@ fn produced_witness_validity() {
                 None => assert!(verified.confirm_nonexistence(&read.key).unwrap()),
                 Some(ref v) => {
                     let leaf = LeafData {
-                        key_path: read.key,
+                        key_path: read.key.clone(),
                         value_hash: *v,
                     };
                     assert!(verified.confirm_value(&leaf).unwrap());
@@ -76,7 +76,7 @@ fn produced_witness_validity() {
             .skip_while(|r| r.path_index != i)
             .take_while(|r| r.path_index == i)
         {
-            write_ops.push((write.key, write.value.clone()));
+            write_ops.push((write.key.clone(), write.value.clone()));
         }
 
         if !write_ops.is_empty() {
@@ -154,7 +154,7 @@ fn test_verify_update_with_identical_paths() {
 
     // First update
     let value1 = ValueHash::default();
-    let ops1 = vec![([0; 32], Some(value1))];
+    let ops1 = vec![(vec![0; 32], Some(value1))];
     updates.push(PathUpdate {
         inner: verified_proof.clone(),
         ops: ops1,
@@ -162,7 +162,7 @@ fn test_verify_update_with_identical_paths() {
 
     // Second update with identical path
     let value2 = ValueHash::default();
-    let ops2 = vec![([1; 32], Some(value2))];
+    let ops2 = vec![(vec![1; 32], Some(value2))];
     updates.push(PathUpdate {
         inner: verified_proof, // Using the same verified proof
         ops: ops2,

--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -342,7 +342,7 @@ impl Agent {
                 let session = session.clone();
                 move || {
                     for key in &reads[start..end] {
-                        let _res = session.read(*key).expect("read failed");
+                        let _res = session.read(key.to_vec()).expect("read failed");
                     }
                 }
             });
@@ -366,10 +366,10 @@ impl Agent {
         for change in changeset {
             match change {
                 KeyValueChange::Insert(key, value) => {
-                    actuals.push((key, nomt::KeyReadWrite::Write(Some(value))));
+                    actuals.push((key.to_vec(), nomt::KeyReadWrite::Write(Some(value))));
                 }
                 KeyValueChange::Delete(key) => {
-                    actuals.push((key, nomt::KeyReadWrite::Write(None)));
+                    actuals.push((key.to_vec(), nomt::KeyReadWrite::Write(None)));
                 }
             }
         }
@@ -408,7 +408,7 @@ impl Agent {
     fn query(&mut self, key: message::Key) -> Result<Option<message::Value>> {
         // UNWRAP: `nomt` is always `Some` except recreation.
         let nomt = self.nomt.as_ref().unwrap();
-        let value = nomt.read(key)?;
+        let value = nomt.read(key.to_vec())?;
         Ok(value)
     }
 


### PR DESCRIPTION
This PR starts the groundwork to allow Nomt to accept variable-length keys. It also updates some bit operations to work with variable-length keys and fixes most of the issues related to changes in signatures throughout the codebase.