### PR TITLE
adapt merkle logic to var len keys

### DIFF
--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -346,7 +346,9 @@ impl ValueChange {
         key: &Key,
         maybe_value: Option<Vec<u8>>,
     ) -> Result<Self> {
-        if key.len() > MAX_KEY_LEN {
+        if key.len() == 0 {
+            return Err(anyhow::anyhow!("Key cannot be empty",));
+        } else if key.len() > MAX_KEY_LEN {
             return Err(anyhow::anyhow!(
                 "Key exceeds limit: {}B > {}B",
                 key.len(),
@@ -822,6 +824,13 @@ mod tests {
             .is_err()
         );
         assert!(
+            ValueChange::from_option::<BinaryHasher<Blake3BinaryHasher>>(&vec![], None).is_err()
+        );
+        assert!(
+            ValueChange::from_option::<BinaryHasher<Blake3BinaryHasher>>(&vec![], Some(vec![1]))
+                .is_err()
+        );
+        assert!(
             ValueChange::from_option::<BinaryHasher<Blake3BinaryHasher>>(
                 &vec![1; MAX_KEY_LEN],
                 None
@@ -839,7 +848,7 @@ mod tests {
 
     #[test]
     fn test_value_change_overflow_limit_adaptation() {
-        for key_len in (0..MAX_KEY_LEN).filter(|x| x % 7 == 0) {
+        for key_len in (1..MAX_KEY_LEN).filter(|x| x % 7 == 0) {
             for value_len in (0..MAX_LEAF_KEY_AND_VALUE_SIZE).filter(|x| x % 7 == 0) {
                 let res = ValueChange::from_option::<BinaryHasher<Blake3BinaryHasher>>(
                     &vec![1; key_len],

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -539,7 +539,13 @@ impl<H: NodeHasher> PageWalker<H> {
         let divisor_bit = (parent_page_id.depth() + 1) * DEPTH;
 
         let left_subtree_ops = std::iter::from_fn(|| {
-            ops.next_if(|(key_path, _)| !key_path.view_bits::<Msb0>()[divisor_bit])
+            ops.next_if(|(key_path, _)| {
+                !key_path
+                    .view_bits::<Msb0>()
+                    .get(divisor_bit)
+                    .map(|bit| *bit)
+                    .unwrap_or(false)
+            })
         });
         let mut left_subtree_position = position.clone();
         left_subtree_position.down(false);

--- a/nomt/tests/fill_and_empty.rs
+++ b/nomt/tests/fill_and_empty.rs
@@ -75,9 +75,9 @@ fn fill_and_empty(seed: [u8; 16], commit_concurrency: usize) {
     assert!(t.commit().0.is_empty());
 }
 
-// TODO: update with random var key size when they will be fully supported
 fn rand_key(rng: &mut impl Rng) -> Vec<u8> {
-    let mut key = vec![0; 32];
+    let key_len = rng.gen_range(1..1024);
+    let mut key = vec![0; key_len];
     rng.fill(&mut key[..]);
     key
 }


### PR DESCRIPTION
Now, nomt fully accept variable-length keys. Updates on how to handle keys that are logically padded with zeros are contained in this PR. Next, some edge cases will be covered, such as keys being fully equal to prefixes of other keys.