### PR TITLE
panic if FullPrefixKeys are encountered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "core",
     "nomt",
-    "fuzz",
+    #"fuzz",
     "torture",
     "examples/*",
     "trickfs",

--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -229,10 +229,9 @@ mod tests {
     use crate::{page_id::MAX_PAGE_DEPTH, trie::MAX_KEY_PATH_LEN};
 
     use super::{
-        ChildPageIdError, ChildPageIndex, InvalidPageIdBytes, Msb0, PageId, PageIdsIterator, Uint,
+        ChildPageIdError, ChildPageIndex, InvalidPageIdBytes, Msb0, PageId, PageIdsIterator,
         MAX_CHILD_INDEX, ROOT_PAGE_ID,
     };
-    use arrayvec::ArrayVec;
     use bitvec::prelude::*;
 
     fn child_page_id(page_id: &PageId, child_index: u8) -> Result<PageId, ChildPageIdError> {
@@ -281,7 +280,7 @@ mod tests {
     #[test]
     fn test_page_ids_iterator() {
         // key_path = 0b000001|000010|0...
-        let mut key_path = vec![0b00000100, 0b00100000];
+        let key_path = vec![0b00000100, 0b00100000];
 
         let page_id_1 = vec![0b000001];
         let page_id_1 = PageId::decode(&page_id_1).unwrap();

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -185,7 +185,7 @@ pub fn build_trie<H: NodeHasher>(
         _ => {}
     }
 
-    while let Some((mut this_key, this_val)) = b {
+    while let Some((this_key, this_val)) = b {
         let n1 = a
             .as_ref()
             .map(|(k, _)| common_after_prefix(k, &this_key, skip));
@@ -283,9 +283,7 @@ pub fn build_trie<H: NodeHasher>(
 
 #[cfg(test)]
 mod tests {
-    use bitvec::view::BitView;
-
-    use crate::trie::{KeyPath, NodeKind, TERMINATOR};
+    use crate::trie::{NodeKind, TERMINATOR};
 
     use super::{bitvec, build_trie, trie, BitVec, LeafData, Msb0, Node, NodeHasher, WriteNode};
 

--- a/nomt/src/beatree/ops/update/leaf_updater.rs
+++ b/nomt/src/beatree/ops/update/leaf_updater.rs
@@ -785,9 +785,7 @@ pub mod tests {
         leaf::node::{body_size, MAX_LEAF_KEY_AND_VALUE_SIZE},
         ops::{
             search_leaf,
-            update::{
-                branch_updater::tests::prefixed_key, leaf_updater::LeafGauge, LEAF_MERGE_THRESHOLD,
-            },
+            update::{leaf_updater::LeafGauge, LEAF_MERGE_THRESHOLD},
         },
     };
 

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -331,6 +331,16 @@ impl<H: NodeHasher> PageWalker<H> {
 
         let start_position = self.position.clone();
 
+        let ops: Vec<_> = ops.into_iter().collect();
+        for window in ops.windows(2) {
+            let (k1, k2) = (&window[0].0, &window[1].0);
+            if k2.starts_with(k1) {
+                if k2[k1.len()..].iter().all(|p| *p == 0) {
+                    unimplemented!("FullPrefixKeys not handled yet");
+                }
+            }
+        }
+
         // replace sub-trie at the given position
         nomt_core::update::build_trie::<H>(self.position.depth() as usize, ops, |control| {
             let node = control.node();

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -19,7 +19,7 @@ use super::{
 };
 
 use nomt_core::{
-    page::{self, DEPTH},
+    page::DEPTH,
     page_id::{PageId, ROOT_PAGE_ID},
     trie::{self, KeyPath, Node, ValueHash},
     trie_pos::TriePosition,

--- a/nomt/src/overlay.rs
+++ b/nomt/src/overlay.rs
@@ -439,7 +439,7 @@ mod tests {
     lazy_static! {
         static ref PAGE_POOL: PagePool = PagePool::new();
     }
-    fn dummy_page(page_id: PageId, value: u8, bucket_info: BucketInfo) -> DirtyPage {
+    fn dummy_page(_page_id: PageId, value: u8, bucket_info: BucketInfo) -> DirtyPage {
         let mut page = PageMut::pristine_empty(&PAGE_POOL);
         page.set_node(0, [value; 32]);
         DirtyPage {

--- a/nomt/tests/compute_root.rs
+++ b/nomt/tests/compute_root.rs
@@ -18,7 +18,7 @@ fn root_on_leaf() {
     {
         let mut t = Test::new("compute_root_leaf");
         t.write(vec![1; 32], Some(vec![1, 2, 3]));
-        let (root, _) = t.commit();
+        t.commit();
     }
 
     let t = Test::new_with_params("compute_root_leaf", 1, 1, None, false);

--- a/nomt/tests/full_prefix.rs
+++ b/nomt/tests/full_prefix.rs
@@ -1,0 +1,28 @@
+mod common;
+use common::Test;
+
+// TODO: Do not expect to panic once FullSharedPrefix keys are handled
+#[test]
+#[should_panic]
+fn full_prefix() {
+    let mut t = Test::new("add_remove");
+    let k1 = vec![4, 5, 128, 0];
+    let mut k2 = k1.clone();
+    k2[2] += 1;
+
+    t.write(k1.clone(), Some(vec![1]));
+    t.write(k2.clone(), Some(vec![2]));
+    t.commit();
+
+    assert_eq!(t.read(k1.clone()), Some(vec![1]));
+    assert_eq!(t.read(k2), Some(vec![2]));
+    t.commit();
+
+    let k3 = k1[..3].to_vec();
+
+    t.write(k3.clone(), Some(vec![3]));
+    t.commit();
+
+    assert_eq!(t.read(k3), Some(vec![3]));
+    t.commit();
+}


### PR DESCRIPTION
Temporary solution: panic in the edge case where keys being inserted are fully prefixes of other keys. This will be addressed later

edit. full prefix concept name changed to 'collision keys', which are keys padded with zeros that 'collide' and result in the same final key