### PR TITLE
feat: detect collision ops and build subtree

### DIFF
--- a/core/src/proof/multi_proof.rs
+++ b/core/src/proof/multi_proof.rs
@@ -896,7 +896,8 @@ fn hash_and_compact_terminal<H: NodeHasher>(
         skip // go to root
     };
 
-    let ops = crate::update::leaf_ops_spliced(leaf, &ops);
+    // TODO: Handle Collisions
+    let ops = crate::update::leaf_ops_spliced(leaf, &ops).map(|(k, v)| (k, v, false));
     let sub_root = crate::update::build_trie::<H>(skip, ops, |_| {});
 
     let mut cur_node = sub_root;
@@ -1394,7 +1395,9 @@ mod tests {
 
         let expected_root = build_trie::<Blake3Hasher>(
             0,
-            ops.clone().into_iter().map(|(k, v)| (k, v.unwrap())),
+            ops.clone()
+                .into_iter()
+                .map(|(k, v)| (k, v.unwrap(), false /*collision*/)),
             |_| {},
         );
 
@@ -1542,10 +1545,10 @@ mod tests {
         ];
 
         let final_state = vec![
-            (key_path_0, [2; 32]),
-            (key_path_4, [1; 32]),
-            (key_path_2, [2; 32]),
-            (key_path_3, [1; 32]),
+            (key_path_0, [2; 32], false /*collision*/),
+            (key_path_4, [1; 32], false),
+            (key_path_2, [2; 32], false),
+            (key_path_3, [1; 32], false),
         ];
 
         let expected_root = build_trie::<Blake3Hasher>(0, final_state, |_| {});

--- a/core/src/proof/path_proof.rs
+++ b/core/src/proof/path_proof.rs
@@ -330,7 +330,8 @@ pub fn verify_update<H: NodeHasher>(
             }
         };
 
-        let ops = crate::update::leaf_ops_spliced(leaf, &ops);
+        // TODO: Handle Collisions
+        let ops = crate::update::leaf_ops_spliced(leaf, &ops).map(|(k, v)| (k, v, false));
         let sub_root = crate::update::build_trie::<H>(skip, ops, |_| {});
 
         let mut cur_node = sub_root;

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -154,6 +154,10 @@ impl SeekRequest {
                     self.continue_leaf_fetch::<H>(None);
                 }
                 return;
+            } else if trie::is_collision_leaf::<H>(&cur_node) {
+                // TODO: now seek is able to encounter some collision leaf which will need
+                // to be handled with its own logic
+                todo!()
             } else if trie::is_terminator::<H>(&cur_node) {
                 self.state = RequestState::Completed(None);
                 return;
@@ -911,7 +915,9 @@ pub struct Seek {
     /// The siblings along the path to the terminal, including the terminal's sibling.
     /// Empty if the seeker wasn't configured to record siblings.
     pub siblings: Vec<Node>,
+    // TODO will require probably something like collision siblings
     /// The terminal node encountered.
+    // TODO: this will be required to change in an enum TerminalEncoutered, LeafData or Container
     pub terminal: Option<trie::LeafData>,
     /// The number of I/Os loaded uniquely for this `Seek`.
     /// This does not include pages loaded from the cache, or pages which were already requested

--- a/nomt/src/merkle/worker.rs
+++ b/nomt/src/merkle/worker.rs
@@ -411,6 +411,8 @@ impl<H: HashAlgorithm> RangeUpdater<H> {
         match ops {
             None => self.page_walker.advance(seek_result.position.clone()),
             Some(ref ops) => {
+                // TODO: this function will need to be updated to not only handle
+                // prev|leaf|after but also prev|container_keys|after
                 let ops = nomt_core::update::leaf_ops_spliced(seek_result.terminal.clone(), &ops);
                 self.page_walker
                     .advance_and_replace(page_set, seek_result.position.clone(), ops)

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -29,9 +29,15 @@ pub fn account_path(id: u64) -> KeyPath {
 pub fn expected_root(accounts: u64) -> Node {
     let mut ops = (0..accounts)
         .map(account_path)
-        .map(|a| (a, *blake3::hash(&1000u64.to_le_bytes()).as_bytes()))
+        .map(|a| {
+            (
+                a,
+                *blake3::hash(&1000u64.to_le_bytes()).as_bytes(),
+                false, /* collision */
+            )
+        })
         .collect::<Vec<_>>();
-    ops.sort_unstable_by_key(|(a, _)| a.clone());
+    ops.sort_unstable_by_key(|(a, _, _)| a.clone());
     nomt_core::update::build_trie::<nomt::hasher::Blake3Hasher>(0, ops, |_| {})
 }
 

--- a/nomt/tests/overlay.rs
+++ b/nomt/tests/overlay.rs
@@ -7,7 +7,7 @@ fn expected_root(items: Vec<(Vec<u8>, Vec<u8>)>) -> nomt_core::trie::Node {
         0,
         items
             .into_iter()
-            .map(|(k, v)| (k, *blake3::hash(&v).as_bytes())),
+            .map(|(k, v)| (k, *blake3::hash(&v).as_bytes(), false /*collision*/)),
         |_| {},
     )
 }


### PR DESCRIPTION
Just before building a subtree on top of a terminal collision, operations are extracted from all the keys that should be written to, firstly to create the collision subtrees and then to use the collision subtree roots as the value hash for the collision leaves.

As explained in #10, this allows us to be as lazy as possible and to only construct the collision subtree when needed.

The padding scheme can now be thought of as follows:
1. Accepting keys smaller than 1 KiB
2. Padding them with zeros up to 1 KiB
3. Appending the length in bytes of the initial key at the end

What is done to construct the collision subtree is simply to look directly at the lengths of the keys and use them as key paths to construct the subtree.