### PR TITLE
chore: remove warnings and fix compilation issue

### DIFF
--- a/nomt/src/beatree/allocator/free_list.rs
+++ b/nomt/src/beatree/allocator/free_list.rs
@@ -139,7 +139,7 @@ impl FreeList {
 
     /// Get a reference to this free list asserted to be clean. This panics if the free list isn't
     /// clean: if any `pop`s have occurred since the last call to `commit`.
-    pub fn as_clean(&self) -> CleanFreeList {
+    pub fn as_clean(&self) -> CleanFreeList<'_> {
         assert!(!self.pop);
         CleanFreeList(self)
     }

--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -59,7 +59,7 @@ impl BranchNode {
         self.page.page()
     }
 
-    pub fn view(&self) -> BranchNodeView {
+    pub fn view(&self) -> BranchNodeView<'_> {
         BranchNodeView {
             inner: self.as_slice(),
         }
@@ -109,7 +109,7 @@ impl BranchNode {
         self.view().prefix()
     }
 
-    pub fn raw_prefix(&self) -> RawPrefix {
+    pub fn raw_prefix(&self) -> RawPrefix<'_> {
         self.view().raw_prefix()
     }
 
@@ -143,11 +143,11 @@ impl BranchNode {
         }
     }
 
-    pub fn raw_separator(&self, i: usize) -> RawSeparator {
+    pub fn raw_separator(&self, i: usize) -> RawSeparator<'_> {
         self.view().raw_separator(i)
     }
 
-    pub fn raw_separators_mut(&mut self, from: usize, to: usize) -> RawSeparatorsMut {
+    pub fn raw_separators_mut(&mut self, from: usize, to: usize) -> RawSeparatorsMut<'_> {
         let RawSeparatorsData {
             start,
             byte_len,

--- a/nomt/src/beatree/iterator.rs
+++ b/nomt/src/beatree/iterator.rs
@@ -186,7 +186,7 @@ impl CurrentLeaf {
         end.map_or(true, |end| &self.leaf.key(self.index - 1) < end)
     }
 
-    fn last_output(&self) -> IterOutput {
+    fn last_output(&self) -> IterOutput<'_> {
         let index = self.index - 1;
         let key = self.leaf.key(index);
         let (cell, overflow) = self.leaf.value(index);

--- a/nomt/src/beatree/ops/update/extend_range_protocol.rs
+++ b/nomt/src/beatree/ops/update/extend_range_protocol.rs
@@ -83,7 +83,7 @@ pub fn try_answer_left_neighbor<Node>(
         .iter()
         .take_while(|(key, entry)| {
             if let Some(ref low) = separator {
-                if low < key {
+                if low < *key {
                     found_unchanged_range = true;
                     new_high_range = Some((**key).clone());
                     return false;

--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -308,7 +308,7 @@ impl Rollback {
     }
 
     #[cfg(test)]
-    pub fn seglog(&self) -> parking_lot::MutexGuard<SegmentedLog> {
+    pub fn seglog(&self) -> parking_lot::MutexGuard<'_, SegmentedLog> {
         self.shared.seglog.lock()
     }
 }

--- a/nomt/src/seglog/segment_rw.rs
+++ b/nomt/src/seglog/segment_rw.rs
@@ -106,7 +106,7 @@ impl SegmentFileReader {
     /// Reads the header of the record.
     ///
     /// Returns `None` if the end of the file is reached.
-    pub fn read_header(&mut self) -> std::io::Result<Option<RecordHeader>> {
+    pub fn read_header(&mut self) -> std::io::Result<Option<RecordHeader<'_>>> {
         if self.next_pos.unwrap_or(0) >= self.file_size {
             return Ok(None);
         }


### PR DESCRIPTION
If nomt is included within a crate that also includes the `bytes` crate, it produces a compilation error:
`the trait `PartialOrd<&Vec<u8>>` is not implemented for `Vec<u8>`` which is solved by dereferencing the `&Vec<u8>`.

This is an open bug within rustc: https://github.com/rust-lang/rust/issues/130464